### PR TITLE
Zhoholiev Pavlo 25.11.24

### DIFF
--- a/home_work_custom_shared_ptr/CMakeLists.txt
+++ b/home_work_custom_shared_ptr/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 project(CustomSharedPTR)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(SOURCE_FILES custom_shared_ptr.cpp, custom_shared_ptr.h)
+set(SOURCE_FILES custom_shared_ptr.cpp custom_shared_ptr.h)
 
 add_executable(CustomSharedPTR custom_shared_ptr.cpp)

--- a/home_work_custom_shared_ptr/CMakeLists.txt
+++ b/home_work_custom_shared_ptr/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(CustomSharedPTR)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(SOURCE_FILES custom_shared_ptr.cpp, custom_shared_ptr.h)
+
+add_executable(CustomSharedPTR custom_shared_ptr.cpp)

--- a/home_work_custom_shared_ptr/build.sh
+++ b/home_work_custom_shared_ptr/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+BUILD_DIR=${1:-build}
+
+if [ -d "$BUILD_DIR" ]; then
+    rm -rf "$BUILD_DIR"/*
+else
+    mkdir -p "$BUILD_DIR"
+fi
+
+cd "$BUILD_DIR"
+
+cmake ..
+cmake --build .
+./CustomSharedPTR
+

--- a/home_work_custom_shared_ptr/custom_shared_ptr.cpp
+++ b/home_work_custom_shared_ptr/custom_shared_ptr.cpp
@@ -1,0 +1,24 @@
+//
+// Created by flyon21 on 21.11.24.
+//
+#include "custom_shared_ptr.h"
+
+int main() {
+    CustomSharedPtr<int> ptr1(new int(42));
+    std::cout << "ptr1 count: " << ptr1.use_count() << std::endl;
+
+    {
+        CustomSharedPtr<int> ptr2 = ptr1;
+        std::cout << "ptr2 count: " << ptr2.use_count() << std::endl;
+
+        *ptr2 = 100;
+        std::cout << "ptr1 value: " << *ptr1 << std::endl;
+    }
+
+    std::cout << "After ptr2 out of scope: " << ptr1.use_count() << std::endl;
+
+    CustomSharedPtr<int> ptr3 = std::move(ptr1);
+    std::cout << "After move, ptr3 count: " << ptr3.use_count() << std::endl;
+
+    return 0;
+}

--- a/home_work_custom_shared_ptr/custom_shared_ptr.h
+++ b/home_work_custom_shared_ptr/custom_shared_ptr.h
@@ -1,0 +1,93 @@
+//
+// Created by flyon21 on 21.11.24.
+//
+
+#ifndef C_PRO_CUSTOM_SHARED_PTR_H_custom_shared_ptr
+#define C_PRO_CUSTOM_SHARED_PTR_H_custom_shared_ptr
+
+#include <iostream>
+#include <atomic>
+#include <stdexcept>
+
+template <typename T>
+class CustomSharedPtr {
+private:
+    T* ptrData;
+    std::atomic<int>* ptrCounter;
+
+    void release() {
+        if (ptrCounter) {
+            if (ptrCounter->fetch_sub(1) == 1) {
+                delete ptrData;
+                delete ptrCounter;
+                ptrData = nullptr;
+                ptrCounter = nullptr;
+            }
+        }
+    }
+
+public:
+
+    explicit CustomSharedPtr(T* value = nullptr)
+            : ptrData(value), ptrCounter(value ? new std::atomic<int>(1) : nullptr) {}
+
+    CustomSharedPtr(const CustomSharedPtr<T>& other)
+            : ptrData(other.ptrData), ptrCounter(other.ptrCounter) {
+        if (ptrCounter) {
+            ptrCounter->fetch_add(1);
+        }
+    }
+
+    CustomSharedPtr(CustomSharedPtr<T>&& other) noexcept
+            : ptrData(other.ptrData), ptrCounter(other.ptrCounter) {
+        other.ptrData = nullptr;
+        other.ptrCounter = nullptr;
+    }
+
+    CustomSharedPtr<T>& operator=(const CustomSharedPtr<T>& other) {
+        if (this != &other) {
+            release();
+            ptrData = other.ptrData;
+            ptrCounter = other.ptrCounter;
+            if (ptrCounter) {
+                ptrCounter->fetch_add(1);
+            }
+        }
+        return *this;
+    }
+
+    CustomSharedPtr<T>& operator=(CustomSharedPtr<T>&& other) noexcept {
+        if (this != &other) {
+            release();
+            ptrData = other.ptrData;
+            ptrCounter = other.ptrCounter;
+            other.ptrData = nullptr;
+            other.ptrCounter = nullptr;
+        }
+        return *this;
+    }
+
+    T& operator*() const {
+        if (!ptrData) {
+            throw std::runtime_error("Dereferencing null pointer");
+        }
+        return *ptrData;
+    }
+
+    T* operator->() const {
+        if (!ptrData) {
+            throw std::runtime_error("Accessing null pointer");
+        }
+        return ptrData;
+    }
+
+    ~CustomSharedPtr() {
+        release();
+    }
+
+    int use_count() const {
+        return ptrCounter ? ptrCounter->load() : 0;
+    }
+};
+
+#endif //C_PRO_CUSTOM_SHARED_PTR_H_custom_shared_ptr


### PR DESCRIPTION
- custom shared_ptr

## Summary by Sourcery

Introduce a custom shared pointer implementation, CustomSharedPtr, to manage shared ownership of objects with reference counting. Include a build script to facilitate the compilation and execution of the project using CMake.

New Features:
- Implement a custom shared pointer class template, CustomSharedPtr, to manage shared ownership of dynamically allocated objects.

Build:
- Add a build script (build.sh) to automate the build process using CMake.