### PR TITLE
Zhoholiev Pavlo 28.11.24

### DIFF
--- a/home_work_custom_shared_ptr/custom_shared_ptr.cpp
+++ b/home_work_custom_shared_ptr/custom_shared_ptr.cpp
@@ -2,23 +2,35 @@
 // Created by flyon21 on 21.11.24.
 //
 #include "custom_shared_ptr.h"
+#include "unordered_set"
 
 int main() {
     CustomSharedPtr<int> ptr1(new int(42));
     std::cout << "ptr1 count: " << ptr1.use_count() << std::endl;
+    CustomSharedPtr<int> ptr2 (new int(56));
 
     {
-        CustomSharedPtr<int> ptr2 = ptr1;
-        std::cout << "ptr2 count: " << ptr2.use_count() << std::endl;
+        CustomSharedPtr<int> ptr3 = ptr1;
+        std::cout << "ptr2 count: " << ptr3.use_count() << std::endl;
 
-        *ptr2 = 100;
+        *ptr3 = 100;
         std::cout << "ptr1 value: " << *ptr1 << std::endl;
+        std::cout << "ptr3 == ptr1: " << (ptr3 == ptr1) << std::endl;
+    }
+    std::cout << "ptr2 == ptr1: " << (ptr2 == ptr1) << std::endl;
+    std::unordered_set<CustomSharedPtr<int>, CustomSharedPtr<int>::Hash> set_ptr;
+    set_ptr.insert(ptr1);
+    set_ptr.insert(ptr2);
+
+    std::cout << "Set data: " << std::endl;
+    for (auto &ptr : set_ptr) {
+        std::cout << *ptr << std::endl;
     }
 
     std::cout << "After ptr2 out of scope: " << ptr1.use_count() << std::endl;
 
-    CustomSharedPtr<int> ptr3 = std::move(ptr1);
-    std::cout << "After move, ptr3 count: " << ptr3.use_count() << std::endl;
+    CustomSharedPtr<int> ptr4 = std::move(ptr1);
+    std::cout << "After move, ptr4 count: " << ptr4.use_count() << std::endl;
 
     return 0;
 }

--- a/home_work_custom_shared_ptr/custom_shared_ptr.h
+++ b/home_work_custom_shared_ptr/custom_shared_ptr.h
@@ -88,6 +88,16 @@ public:
     int use_count() const {
         return ptrCounter ? ptrCounter->load() : 0;
     }
+
+    bool operator==(const CustomSharedPtr<T>& other) const {
+        return ptrData == other.ptrData;
+    }
+
+    struct Hash {
+        size_t operator()(const CustomSharedPtr<T>& ptr) const {
+            return std::hash<T*>()(ptr.ptrData);
+        }
+    };
 };
 
 #endif //C_PRO_CUSTOM_SHARED_PTR_H_custom_shared_ptr


### PR DESCRIPTION
- add Hash and overload operator ==

## Summary by Sourcery

Enhance the CustomSharedPtr class by overloading the equality operator to allow direct comparison of pointer data and introducing a Hash struct to enable its use in unordered containers like unordered_set.

New Features:
- Introduce a Hash struct for CustomSharedPtr to enable its use in unordered containers.

Enhancements:
- Overload the equality operator (==) for CustomSharedPtr to allow direct comparison of pointer data.